### PR TITLE
Fix goreleaser action

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      # write is needed for creating releases
+      contents: write
     steps:
       -
         name: Checkout

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -21,13 +21,16 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v3
+        with:
+          go-version: "1.21"
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          # either 'goreleaser' (default) or 'goreleaser-pro'
           distribution: goreleaser
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
Moving our project to an organization, the way permissions are handled is slightly different so we need to call out which permissions our jobs need in order to create our releases automatically.

This also fixes a deprecation issue with goreleaser, which changes the `--rm-dist` flag to `--clean` and forces the Go version to match our minimum of 1.21.