### PR TITLE
chore: Fix commit message check

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check Commit Subject Prefix
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^((fix|feat|chore|docs|test|refactor|revert|test)(\[[^]]+\])?:\ |[Mm]erge\ pull\ request\ ).*$'
+          pattern: '^((fix|feat|chore|docs|test|refactor|revert|test)(\([^)]+\))?:\ |[Mm]erge\ pull\ request\ ).*$'
           flags: 'gm'
           error: >-
             Your first line is missing a valid subject prefix. See Commit


### PR DESCRIPTION
Scope should be in parens and not square brackets