### PR TITLE
feat: Add option to disable URL unfurling in Slacker

### DIFF
--- a/examples/message-unfurl/main.go
+++ b/examples/message-unfurl/main.go
@@ -1,0 +1,32 @@
+// main.go
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/slack-io/slacker"
+)
+
+// Defining commands using slacker
+
+func main() {
+	bot := slacker.NewClient(os.Getenv("SLACK_BOT_TOKEN"), os.Getenv("SLACK_APP_TOKEN"))
+
+	bot.AddCommand(&slacker.CommandDefinition{
+		Command: "without",
+		Handler: func(ctx *slacker.CommandContext) {
+			ctx.Response().Reply("https://www.youtube.com/watch?v=dQw4w9WgXcQ", slacker.WithUnfurlLinks(false))
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := bot.Listen(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -108,12 +108,20 @@ func WithSchedule(timestamp time.Time) ReplyOption {
 	}
 }
 
+// WithUnfurlLinks sets the unfurl_links option
+func WithUnfurlLinks(unfurlLinks bool) ReplyOption {
+	return func(defaults *replyOptions) {
+		defaults.UnfurlLinks = &unfurlLinks
+	}
+}
+
 type replyOptions struct {
 	Attachments      []slack.Attachment
 	InThread         *bool
 	ReplaceMessageTS string
 	IsEphemeral      bool
 	ScheduleTime     *time.Time
+	UnfurlLinks      *bool
 }
 
 // newReplyOptions builds our ReplyOptions from zero or more ReplyOption.
@@ -167,12 +175,20 @@ func SetSchedule(timestamp time.Time) PostOption {
 	}
 }
 
+// SetUnfurlLinks sets the unfurl_links option
+func SetUnfurlLinks(unfurlLinks bool) PostOption {
+	return func(defaults *postOptions) {
+		defaults.UnfurlLinks = &unfurlLinks
+	}
+}
+
 type postOptions struct {
 	Attachments      []slack.Attachment
 	ThreadTS         string
 	ReplaceMessageTS string
 	EphemeralUserID  string
 	ScheduleTime     *time.Time
+	UnfurlLinks      *bool
 }
 
 // newPostOptions builds our PostOptions from zero or more PostOption.

--- a/response_replier.go
+++ b/response_replier.go
@@ -58,5 +58,10 @@ func (r *Replier) convertOptions(options ...ReplyOption) []PostOption {
 	if replyOptions.ScheduleTime != nil {
 		responseOptions = append(responseOptions, SetSchedule(*replyOptions.ScheduleTime))
 	}
+
+	if replyOptions.UnfurlLinks != nil {
+		responseOptions = append(responseOptions, SetUnfurlLinks(*replyOptions.UnfurlLinks))
+	}
+
 	return responseOptions
 }

--- a/response_writer.go
+++ b/response_writer.go
@@ -77,6 +77,13 @@ func (r *Writer) post(channel string, message string, blocks []slack.Block, opti
 		opts = append(opts, slack.MsgOptionSchedule(postAt))
 	}
 
+	// response_writer.go
+	if postOptions.UnfurlLinks != nil {
+		if !*postOptions.UnfurlLinks {
+			opts = append(opts, slack.MsgOptionDisableLinkUnfurl(), slack.MsgOptionDisableMediaUnfurl())
+		}
+	}
+
 	_, timestamp, err := r.slackClient.PostMessageContext(
 		r.ctx,
 		channel,


### PR DESCRIPTION
Add a feature to allow users to choose not to unfurl a URL or link when using Slacker. 
This is useful for cases where unfurling is not desired or necessary. 
Additionally, a test case for this feature has been added to main.go.

Closes #11